### PR TITLE
Set host URL based on environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
+ARG ENVIRONMENT=local
 FROM maven:3.6.1-jdk-8 AS build
 COPY pom.xml /usr/src/app/pom.xml
 COPY src /usr/src/app/src
 RUN mvn -f /usr/src/app/pom.xml clean package
 
 FROM jetty:9-jre8-alpine
+ARG ENVIRONMENT
+ENV ENV=$ENVIRONMENT
 COPY --from=build /usr/src/app/target/root.war /var/lib/jetty/webapps/root.war
 COPY --from=build /usr/src/app/target /var/lib/jetty/target 
 ADD ./data /var/lib/jetty/target/

--- a/src/main/java/ca/uhn/fhir/jpa/starter/HapiProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/HapiProperties.java
@@ -250,7 +250,16 @@ public class HapiProperties {
     }
 
     public static String getServerAddress() {
-        return HapiProperties.getProperty(SERVER_ADDRESS);
+        String environment = System.getenv("ENV");
+        String serverAddress = HapiProperties.getProperty(SERVER_ADDRESS);
+
+        if (environment != null && environment.equalsIgnoreCase("DEV")) {
+          serverAddress = "https://fhir.dev.devoted.com/fhir";
+        } else if (environment != null && environment.equalsIgnoreCase("PROD")) {
+          serverAddress = "https://fhir.devoted.com/fhir";
+        }
+
+        return serverAddress;
     }
 
     public static Integer getDefaultPageSize() {

--- a/src/main/resources/hapi.properties
+++ b/src/main/resources/hapi.properties
@@ -11,8 +11,8 @@ fhir_version=R4
 # (the web UI similar to the one at http://hapi.fhir.org) will use to
 # connect internally to the FHIR server, so this also needs to be a name
 # accessible from the server itself.
-# TODO make this dynamic
-server_address=https://fhir.devoted.com/fhir
+# This is overriden for the hosted environment in JpaRestfulServer.java
+server_address=http://localhost:8080/fhir
 
 enable_index_missing_fields=false
 auto_create_placeholder_reference_targets=true

--- a/src/main/resources/hapi.properties
+++ b/src/main/resources/hapi.properties
@@ -11,7 +11,7 @@ fhir_version=R4
 # (the web UI similar to the one at http://hapi.fhir.org) will use to
 # connect internally to the FHIR server, so this also needs to be a name
 # accessible from the server itself.
-# This is overriden for the hosted environment in JpaRestfulServer.java
+# This is overriden for the hosted environment in HapiProperties.java
 server_address=http://localhost:8080/fhir
 
 enable_index_missing_fields=false


### PR DESCRIPTION
This will update the host URL used in the test UI to send requests to the host server. 

I tested this by passing 'dev' and 'prod' build_args through the docker build command to make sure it updated correctly