### PR TITLE
Pin rdoc version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apk add --update \
     ruby-json \
     zlib-dev \
     && rm -rf /var/cache/apk/*
-RUN gem install rdoc --no-document
+RUN gem install rdoc -v '6.3.3' --no-document
 RUN gem install zip
 RUN gem install bundler
 RUN gem install etc


### PR DESCRIPTION
**What this PR does / why we need it:**
- Pin the rdoc version to avoid breaking changes in the 6.4.0 release (installs of gems installed after it were failing due to it pulling in a new version of psych)

**What are the risks associated with this PR:**
- NA, builds are broken right now

**What is the rollback plan:**
- Revert

How this PR was tested:
- `cd aws-infrastructure/tools/fhir_api && make run`

(Optional) Any other notes for your reviewer: